### PR TITLE
Fixed error on product duplication

### DIFF
--- a/Helper/TrackField.php
+++ b/Helper/TrackField.php
@@ -658,7 +658,7 @@ class TrackField extends \Magento\Framework\App\Helper\AbstractHelper
         if ($method == self::PRODUCT_METHOD) {
             $newQty = $model->getData('stock_data');
             $oldQty = $model->getOrigData('quantity_and_stock_status');
-            if ($newQty['qty'] != $oldQty['qty']) {
+            if (isset($newQty['qty']) && isset($oldQty['qty']) && $newQty['qty'] != $oldQty['qty']) {
                 $logData['qty'] = [
                     'old_value' => $oldQty['qty'],
                     'new_value' => $newQty['qty']


### PR DESCRIPTION
Fix for:
When try to Save & Duplicate product get this error
Notice: Undefined index: qty in /vendor/kiwicommerce/module-admin-activity/Helper/TrackField.php on line 661