### PR TITLE
Possibility to split config path containing only two parts

### DIFF
--- a/Model/Activity/SystemConfig.php
+++ b/Model/Activity/SystemConfig.php
@@ -77,11 +77,16 @@ class SystemConfig implements \KiwiCommerce\AdminActivity\Api\Activity\ModelInte
     public function getOldData($model)
     {
         $path = $this->getPath($model);
-        $systemData = $this->valueFactory->create()->getCollection()
-                            ->addFieldToFilter('path', ['like'=> $path.'/%']);
+        $systemData = $this->valueFactory->create()->getCollection()->addFieldToFilter('path', ['like'=> $path.'/%']);
         $data = [];
         foreach ($systemData->getData() as $config) {
-            list($path, $group, $field) = explode('/', $config['path']);
+            $splittedPath = explode('/', $config['path']);
+            if (count($splittedPath) === 2) {
+                [$group, $field] = explode('/', $config['path']);
+            } else {
+                [$path, $group, $field] = explode('/', $config['path']);
+            }
+
             $data[$group]['fields'][$field]['value'] = $config['value'];
         }
 


### PR DESCRIPTION
3rd party modules might save config data under the hood containing only two parts. e.g. `cache_warmer/unique_value`