### PR TITLE
enable configuration merging for modules node

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -49,6 +49,9 @@
             <argument name="converter" xsi:type="object">KiwiCommerce\AdminActivity\Model\Config\Converter</argument>
             <argument name="schemaLocator" xsi:type="object">KiwiCommerce\AdminActivity\Model\Config\SchemaLocator</argument>
             <argument name="fileName" xsi:type="string">adminactivity.xml</argument>
+            <argument name="idAttributes" xsi:type="array">
+                <item name="/config/modules/module" xsi:type="string">name</item>
+            </argument>
         </arguments>
     </virtualType>
 


### PR DESCRIPTION
fixes 'More than one node matching the query: /config/modules/module' exception if another module attempts to add a adminactivity.xml file. See idAttributes parameter here https://devdocs.magento.com/guides/v2.3/config-guide/config/config-create.html#config-files-extend-create-create